### PR TITLE
投稿の削除機能実装

### DIFF
--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -13,6 +13,11 @@ class TweetsController < ApplicationController
     Tweet.create(tweet_params)
   end
 
+  def destroy
+    tweet = Tweet.find(params[:id])
+    tweet.destroy
+  end
+  
   private
   def tweet_params
     params.require(:tweet).permit(:distance, :image)

--- a/app/views/tweets/destroy.html.haml
+++ b/app/views/tweets/destroy.html.haml
@@ -1,0 +1,4 @@
+.contents.row
+  .success
+    %h3 削除が完了しました。
+    %a.btn{:href => "/"} 投稿一覧へ戻る

--- a/app/views/tweets/index.html.haml
+++ b/app/views/tweets/index.html.haml
@@ -38,8 +38,13 @@
       .contents.row
         - @tweets.each do |tweet|
           .content_post{:style => "background-image: url(#{tweet.image});"}
+            .more
+              %span= image_tag 'arrow_top.png'
+              %ul.more_list
+                %li
+                  = link_to '削除', tweet_path(tweet.id), method: :delete
             %p= tweet.distance
-            %span.name
+
 
   .Main__visual
     .Main__visual__content
@@ -53,5 +58,4 @@
           = link_to image_tag("apple.svg", class:"App_img"), "/"
         .Main__visual__content__icon__gBtn
           = link_to image_tag("google.svg", class:"Google_img"), "/"
-
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   root 'tweets#index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  resources :tweets, only: [:index, :new, :create]
+  resources :tweets, only: [:index, :new, :create, :destroy]
 end


### PR DESCRIPTION
#What
投稿の削除機能の実装。
ツイートを削除できるようにし、削除後のビューを作成。

#Why
ユーザーが過去のツイートを削除できるようにすることで、
ユーザーが使いやすくするため。