### PR TITLE
投稿の詳細表示、編集機能の実装

### DIFF
--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -17,6 +17,15 @@ class TweetsController < ApplicationController
     tweet = Tweet.find(params[:id])
     tweet.destroy
   end
+
+  def edit
+    @tweet = Tweet.find(params[:id])
+  end
+
+  def update
+    tweet = Tweet.find(params[:id])
+    tweet.update(tweet_params)
+  end
   
   private
   def tweet_params

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -1,4 +1,5 @@
 class TweetsController < ApplicationController
+  before_action :set_tweet, only: [:edit, :show]
 
   def index
     @tweets = Tweet.all
@@ -7,7 +8,6 @@ class TweetsController < ApplicationController
   def new
     @tweet = Tweet.new
   end
-
 
   def create
     Tweet.create(tweet_params)
@@ -19,17 +19,23 @@ class TweetsController < ApplicationController
   end
 
   def edit
-    @tweet = Tweet.find(params[:id])
   end
 
   def update
     tweet = Tweet.find(params[:id])
     tweet.update(tweet_params)
   end
-  
-  private
-  def tweet_params
-    params.require(:tweet).permit(:distance, :image)
+
+  def show
   end
 
+  private
+
+  def tweet_params
+    params.require(:tweet).permit(:name, :image, :text)
+  end
+
+  def set_tweet
+    @tweet = Tweet.find(params[:id])
+  end
 end

--- a/app/views/tweets/edit.html.haml
+++ b/app/views/tweets/edit.html.haml
@@ -1,8 +1,7 @@
 .contents.row
   .container
+    %h3 編集する
     = form_with(model: @tweet, local: true) do |form|
-      %h3 投稿する
       = form.text_field :image, placeholder: "Image Url"
       = form.text_field :distance, placeholder: "Distance"
-      -# = form.text_area :text, placeholder: "text", rows: "10"
-      = form.submit "投稿する"
+      = form.submit "SEND"

--- a/app/views/tweets/index.html.haml
+++ b/app/views/tweets/index.html.haml
@@ -42,11 +42,12 @@
               %span= image_tag 'arrow_top.png'
               %ul.more_list
                 %li
-                  = link_to '削除', tweet_path(tweet.id), method: :delete
+                  = link_to '詳細', tweet_path(tweet.id), method: :get
                 %li
                   = link_to '編集', edit_tweet_path(tweet.id), method: :get
+                %li
+                  = link_to '削除', tweet_path(tweet.id), method: :delete
             %p= tweet.distance
-
 
   .Main__visual
     .Main__visual__content

--- a/app/views/tweets/index.html.haml
+++ b/app/views/tweets/index.html.haml
@@ -43,6 +43,8 @@
               %ul.more_list
                 %li
                   = link_to '削除', tweet_path(tweet.id), method: :delete
+                %li
+                  = link_to '編集', edit_tweet_path(tweet.id), method: :get
             %p= tweet.distance
 
 

--- a/app/views/tweets/show.html.haml
+++ b/app/views/tweets/show.html.haml
@@ -1,0 +1,10 @@
+.contents.row
+  .content_post{:style => "background-image: url(#{@tweet.image});"}
+    .more
+      %span= image_tag 'arrow_top.png'
+      %ul.more_list
+        %li
+          = link_to '編集', edit_tweet_path(@tweet.id), method: :get
+        %li
+          = link_to '削除', tweet_path(@tweet.id), method: :delete
+    %p= @tweet.distance

--- a/app/views/tweets/update.html.haml
+++ b/app/views/tweets/update.html.haml
@@ -1,0 +1,4 @@
+.contents.row
+  .success
+    %h3 更新が完了しました。
+    %a.btn{:href => "/"} 投稿一覧へ戻る

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   root 'tweets#index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  resources :tweets, only: [:index, :new, :create, :destroy, :edit, :update]
+  resources :tweets
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   root 'tweets#index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  resources :tweets, only: [:index, :new, :create, :destroy]
+  resources :tweets, only: [:index, :new, :create, :destroy, :edit, :update]
 end


### PR DESCRIPTION
#What
投稿の詳細表示機能の実装と
投稿の編集機能の実装。
コードのリファクタリング。

#Why
詳細機能は今後、コメント機能を実装する上で、
コメントを閲覧するのに必須の機能だから。

編集機能を実装する事で、ユーザーが投稿のミスや変更がある場合に役立つため。

コードの可読性や、今後の開発をスムーズにするため。